### PR TITLE
Add ArticleSummaryNotice command

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,29 @@
+language: "jp"
+early_access: false
+reviews:
+    request_changes_workflow: false
+    high_level_summary: true
+    poem: true
+    review_status: true
+    collapse_walkthrough: false
+    path_filters:
+        - "!**/.xml"
+    path_instructions:
+        - path: "**/*.js"
+          instructions: "Review the JavaScript code for conformity with the Google JavaScript style guide, highlighting any deviations."
+        - path: "tests/**/*"
+          instructions: |
+              "Assess the unit test code employing the Mocha testing framework. Confirm that:
+              - The tests adhere to Mocha's established best practices.
+              - Test descriptions are sufficiently detailed to clarify the purpose of each test."
+    auto_review:
+        enabled: true
+        ignore_title_keywords:
+            - "WIP"
+            - "DO NOT MERGE"
+        drafts: false
+        base_branches:
+            - "develop"
+            - "feature/*"
+chat:
+    auto_reply: true

--- a/app/Console/Commands/ArticleSummaryNotice.php
+++ b/app/Console/Commands/ArticleSummaryNotice.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class ArticleSummaryNotice extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:article-summary-notice';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'はてなブックマークのテクノロジーカテゴリのホットエントリーを取得。
+        5つまでの記事を取得。
+        chatGPT apiを使用して記事を要約。
+        指定したSlackに通知する';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // はてなブックマークのテクノロジーカテゴリのホットエントリーを取得する
+        // こちらの処理は専用のServiceクラスに切り出す
+        // 5つまでの記事URLを取得する
+
+        // ここからloopでの処理を予定
+
+        // 取得したリンク先の記事本文を取得するクラスを呼び出す
+
+        // chatGPT apiを使用して記事を要約する
+
+        // Slackに通知する
+    }
+}


### PR DESCRIPTION
This pull request adds a new command called ArticleSummaryNotice to the application. This command retrieves the hot entries from the technology category of Hatena Bookmark, summarizes the articles using the chatGPT API, and sends notifications to a specified Slack channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new console command that automatically fetches, summarizes, and sends notifications about hot technology articles to a specified Slack channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->