### PR TITLE
RSSのパース処理を実装

### DIFF
--- a/app/Console/Commands/ArticleSummaryNotice.php
+++ b/app/Console/Commands/ArticleSummaryNotice.php
@@ -33,7 +33,14 @@ class ArticleSummaryNotice extends Command
         // こちらの処理は専用のServiceクラスに切り出す
         // 5つまでの記事URLを取得する
         $parse_service = new RSSParseService();
-        $hot_entries = $parse_service->fetchEntries(5);
+        // ここでエラーが発生する場合は処理を中断する
+        try {
+            $hot_entries = $parse_service->fetchEntries(5);
+        } catch (\Throwable $th) {
+            // 通知に関してはServiceクラス内で行う
+            $this->error($th->getMessage());
+            return;
+        }
 
         // ここからloopでの処理を予定
 

--- a/app/Console/Commands/ArticleSummaryNotice.php
+++ b/app/Console/Commands/ArticleSummaryNotice.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Services\RSSParseService;
 use Illuminate\Console\Command;
 
 class ArticleSummaryNotice extends Command
@@ -31,6 +32,8 @@ class ArticleSummaryNotice extends Command
         // はてなブックマークのテクノロジーカテゴリのホットエントリーを取得する
         // こちらの処理は専用のServiceクラスに切り出す
         // 5つまでの記事URLを取得する
+        $parse_service = new RSSParseService();
+        $hot_entries = $parse_service->fetchEntries(5);
 
         // ここからloopでの処理を予定
 

--- a/app/Services/RSSParseService.php
+++ b/app/Services/RSSParseService.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use SimpleXMLElement;
+
+class RSSParseService
+{
+    private $rss_url;
+
+    /**
+     * デフォルトははてなブックマークのITカテゴリのRSS
+     *
+     * @param string $rss_url
+     */
+    public function __construct($rss_url = 'https://b.hatena.ne.jp/hotentry/it.rss')
+    {
+        $this->rss_url = $rss_url;
+    }
+
+    /**
+     * RSSをパースしてtitleとlinkを格納した配列を返す
+     *
+     * @param int $limit
+     * @return array
+     * @throws \Throwable
+     */
+    public function fetchEntries(int $limit = 5): array
+    {
+        try {
+            $response = Http::get($this->rss_url);
+            $rss = new SimpleXMLElement($response->body());
+
+            // RSSのitem数とlimitの小さい方を取得する limit数がRSSのitem数より多い場合にエラーになるのを防ぐ
+            $count = min($limit, count($rss->item));
+
+            $top_entries = [];
+            for ($i = 0; $i < $count; $i++) {
+                $top_entries[] = [
+                    'title' => (string) $rss->item[$i]->title,
+                    'link' => (string) $rss->item[$i]->link,
+                ];
+            }
+            return $top_entries;
+        } catch (\Throwable $th) {
+            throw $th;
+        }
+    }
+}

--- a/app/Services/RSSParseService.php
+++ b/app/Services/RSSParseService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 use SimpleXMLElement;
 
@@ -16,7 +17,43 @@ class RSSParseService
      */
     public function __construct($rss_url = 'https://b.hatena.ne.jp/hotentry/it.rss')
     {
+        $this->checkUrl($rss_url);
         $this->rss_url = $rss_url;
+    }
+
+    /**
+     * URLが正しい形式かどうかをチェックする
+     *
+     * @param string $url
+     * @return void
+     */
+    private function checkUrl(string $rss_url): void
+    {
+        if (filter_var($rss_url, FILTER_VALIDATE_URL) === false) {
+            throw new \InvalidArgumentException('Invalid RSS URL provided');
+        }
+    }
+
+    /**
+     * 取得したRSSが正しい形式かどうかをチェックする
+     *
+     * @param \Illuminate\Http\Client\Response $response
+     * @return void
+     * @throws \InvalidArgumentException
+     */
+    private function validateRss(Response $response): void
+    {
+        try {
+            new SimpleXMLElement($response->body());
+        } catch (\Throwable $th) {
+            throw new \InvalidArgumentException('Invalid RSS feed.');
+        }
+
+        if (count(libxml_get_errors()) > 0) {
+            throw new \InvalidArgumentException('Invalid RSS feed.');
+        }
+
+        libxml_clear_errors();
     }
 
     /**
@@ -30,20 +67,36 @@ class RSSParseService
     {
         try {
             $response = Http::get($this->rss_url);
+
+            // レスポンスが失敗した場合は例外を投げる
+            if ($response->failed()) {
+                throw new \InvalidArgumentException('Failed to fetch RSS URL.');
+            }
+
+            // レスポンスが成功した場合はRSSが正しい形式かどうかをチェックする
+            $this->validateRss($response);
+
             $rss = new SimpleXMLElement($response->body());
 
-            // RSSのitem数とlimitの小さい方を取得する limit数がRSSのitem数より多い場合にエラーになるのを防ぐ
-            $count = min($limit, count($rss->item));
+            // 一度jsonに変換してから配列に変換する
+            $rss = json_decode(json_encode($rss));
 
-            $top_entries = [];
-            for ($i = 0; $i < $count; $i++) {
-                $top_entries[] = [
-                    'title' => (string) $rss->item[$i]->title,
-                    'link' => (string) $rss->item[$i]->link,
+            $items = $rss->item;
+            // $itemsをlimit数の数だけ取得
+            $items = array_slice($items, 0, $limit);
+
+            $hot_entries = array_map(function ($item) {
+                return [
+                    'title' => (string) $item->title,
+                    'link' => (string) $item->link,
                 ];
-            }
-            return $top_entries;
+            }, $items);
+
+            return $hot_entries;
         } catch (\Throwable $th) {
+            // 例外をキャッチしてログに出力する
+            logger()->error($th);
+            // TODO: slackにエラーを通知する
             throw $th;
         }
     }

--- a/tests/Unit/Services/RSSParseServiceTest.php
+++ b/tests/Unit/Services/RSSParseServiceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+// use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
+use App\Services\RSSParseService;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * test 実行コマンド: vendor/bin/phpunit tests/Unit/Services/RSSParseServiceTest.php
+ * sail ver 実行コマンド: sail test tests/Unit/Services/RSSParseServiceTest.php
+ */
+class RSSParseServiceTest extends TestCase
+{
+    /**
+     * Test RSS parsing.
+     */
+    public function test_RSSのパース成功(): void
+    {
+        // Create an instance of the RSSParseService
+        $rss_parse_service = new RSSParseService();
+
+        // Mock the RSS feed data
+        $rss_mock = '
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/" xmlns:admin="http://webns.net/mvcb/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:syn="http://purl.org/rss/1.0/modules/syndication/" xmlns:taxo="http://purl.org/rss/1.0/modules/taxonomy/">
+            <channel>
+                <items>
+                    <rdf:Seq>
+                        <rdf:li rdf:resource="https://example.com/item1"/>
+                        <rdf:li rdf:resource="https://example.com/item2"/>
+                    </rdf:Seq>
+                </items>
+            </channel>
+            <item rdf:about="https://example.com/item1">
+                <title>Item 1</title>
+                <link>https://example.com/item1</link>
+            </item>
+            <item rdf:about="https://example.com/item2">
+                <title>Item 2</title>
+                <link>https://example.com/item2</link>
+            </item>
+        </rdf:RDF>';
+
+        // Mock the Http facade to return the RSS feed data
+        Http::fake([
+            '*' => Http::response($rss_mock, 200),
+        ]);
+
+        // Call the parse method and assert the result
+        $response = $rss_parse_service->fetchEntries();
+
+        $expected_data = [
+            [
+                'title' => 'Item 1',
+                'link' => 'https://example.com/item1',
+            ],
+            [
+                'title' => 'Item 2',
+                'link' => 'https://example.com/item2',
+            ],
+        ];
+
+        $this->assertEquals($expected_data, $response);
+    }
+}

--- a/tests/Unit/Services/RSSParseServiceTest.php
+++ b/tests/Unit/Services/RSSParseServiceTest.php
@@ -63,4 +63,34 @@ class RSSParseServiceTest extends TestCase
 
         $this->assertEquals($expected_data, $response);
     }
+
+    public function test_RSSへの通信に失敗(): void
+    {
+        // Create an instance of the RSSParseService
+        $rss_parse_service = new RSSParseService();
+
+        // Mock the Http facade to return a failed response
+        Http::fake([
+            '*' => Http::response('', 500),
+        ]);
+
+        // Call the parse method and assert the result
+        $this->expectException(\InvalidArgumentException::class);
+        $rss_parse_service->fetchEntries();
+    }
+
+    public function test_提供されたURLがRSSフィードを含まない(): void
+    {
+        // Create an instance of the RSSParseService
+        $rss_parse_service = new RSSParseService('https://example.com');
+
+        // Mock the Http facade to return a failed response
+        Http::fake([
+            '*' => Http::response('', 200),
+        ]);
+
+        // Call the parse method and assert the result
+        $this->expectException(\InvalidArgumentException::class);
+        $rss_parse_service->fetchEntries();
+    }
 }


### PR DESCRIPTION
・はてなブックマークのテクノロジー　ホットエントリーのRSSを取得して、titleとlinkの連想配列形式にパース処理するServiceクラスを実装
・作成したServiceクラスのunitテストを実装（簡易）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - Hatena Bookmarkから技術カテゴリのホットエントリー5件を取得する機能を追加しました。
- **テスト**
    - RSSパース機能のユニットテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->