### PR TITLE
サイト本文を取得するServiceクラスの作成

### DIFF
--- a/app/Services/RSSParseService.php
+++ b/app/Services/RSSParseService.php
@@ -99,6 +99,9 @@ class RSSParseService
             // レスポンスが成功した場合はRSSが正しい形式かどうかをチェックする
             $this->validateRss($response);
 
+            // Memo コメントにあるように、効率的な方法があるのかを検討する
+            // json_decode(json_encode($rss))を使用してオブジェクトを配列に変換している部分については、より効率的な方法を検討する価値があります。
+            // 例えば、SimpleXMLElementオブジェクトを直接操作して必要なデータを抽出する方法などです。
             $rss = new SimpleXMLElement($response->body());
 
             // 一度jsonに変換してから配列に変換する

--- a/app/Services/RSSParseService.php
+++ b/app/Services/RSSParseService.php
@@ -93,6 +93,9 @@ class RSSParseService
 
             // レスポンスが失敗した場合は例外を投げる
             if ($response->failed()) {
+                // なぜ失敗したのかをログに残す
+                logger()->error($response->body());
+                // TODO: slackにエラーを通知する
                 throw new \InvalidArgumentException('Failed to fetch RSS URL.');
             }
 

--- a/app/Services/WebContentFetchService.php
+++ b/app/Services/WebContentFetchService.php
@@ -32,8 +32,10 @@ class WebContentFetchService
             ]);
 
             if ($response->failed()) {
-                // なぜ失敗したのかを例外に含める
-                throw new \RuntimeException('Failed to fetch content. ' . $response->body());
+                // なぜ失敗したのかをログに残す
+                logger()->error($response->body());
+                // TODO: slackにエラーを通知する
+                throw new \RuntimeException('Failed to fetch content.');
             }
 
             // json形式のレスポンスを配列に変換

--- a/app/Services/WebContentFetchService.php
+++ b/app/Services/WebContentFetchService.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+/**
+ * 指定したサイトの本文を取得する
+ */
+class WebContentFetchService
+{
+    /**
+     * 指定したURLの本文を取得する
+     *
+     * @param array $urls
+     * @return array
+     */
+    public static function fetchContent(array $urls): array
+    {
+        // サイト本文を取得するapiを叩く
+        // headerにAuthorizationをつける
+        try {
+            $response = Http::withHeaders([
+                'Authorization' => config('services.lambda.authorization'),
+            ])->post(config('services.lambda.endpoint'), [
+                'urls' => $urls,
+            ]);
+
+            if ($response->failed()) {
+                // なぜ失敗したのかを例外に含める
+                throw new \RuntimeException('Failed to fetch content. ' . $response->body());
+            }
+
+            // json形式のレスポンスを配列に変換
+            return $response->json();
+
+        } catch (\Throwable $th) {
+            logger()->error($th);
+            throw $th;
+        }
+    }
+}
+

--- a/app/Services/WebContentFetchService.php
+++ b/app/Services/WebContentFetchService.php
@@ -41,6 +41,7 @@ class WebContentFetchService
 
         } catch (\Throwable $th) {
             logger()->error($th);
+            // TODO: slackにエラーを通知する
             throw $th;
         }
     }

--- a/app/Services/WebContentFetchService.php
+++ b/app/Services/WebContentFetchService.php
@@ -15,8 +15,13 @@ class WebContentFetchService
      * @param array $urls
      * @return array
      */
-    public static function fetchContent(array $urls): array
+    public function fetchContent(array $urls): array
     {
+        // 万が一URLが空の場合は例外を投げる
+        if (empty($urls)) {
+            throw new \InvalidArgumentException('URLs are empty.');
+        }
+
         // サイト本文を取得するapiを叩く
         // headerにAuthorizationをつける
         try {
@@ -40,4 +45,3 @@ class WebContentFetchService
         }
     }
 }
-

--- a/config/services.php
+++ b/config/services.php
@@ -31,4 +31,14 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    'rss' => [
+        'mentas' => env('RSS_MENTAS'),
+        'hatena_hotentry' => env('RSS_HATENA_HOTENTRY'),
+    ],
+
+    'lambda' => [
+        'endpoint' => env('LAMBDA_ENDPOINT'),
+        'authorization' => env('LAMBDA_AUTHORIZATION'),
+    ],
+
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -32,8 +32,8 @@ return [
     ],
 
     'rss' => [
-        'mentas' => env('RSS_MENTAS'),
-        'hatena_hotentry' => env('RSS_HATENA_HOTENTRY'),
+        'mentas' => env('RSS_MENTAS', 'https://menthas.com/programming/rss'),
+        'hatena_hotentry' => env('RSS_HATENA_HOTENTRY', 'https://b.hatena.ne.jp/hotentry/it.rss'),
     ],
 
     'lambda' => [

--- a/tests/Unit/Services/RSSParseServiceTest.php
+++ b/tests/Unit/Services/RSSParseServiceTest.php
@@ -51,14 +51,8 @@ class RSSParseServiceTest extends TestCase
         $response = $rss_parse_service->fetchEntries();
 
         $expected_data = [
-            [
-                'title' => 'Item 1',
-                'link' => 'https://example.com/item1',
-            ],
-            [
-                'title' => 'Item 2',
-                'link' => 'https://example.com/item2',
-            ],
+            'https://example.com/item1',
+            'https://example.com/item2',
         ];
 
         $this->assertEquals($expected_data, $response);

--- a/tests/Unit/Services/WebContentFetchServiceTest.php
+++ b/tests/Unit/Services/WebContentFetchServiceTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Unit;
+
+// use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
+use App\Services\WebContentFetchService;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * test 実行コマンド: vendor/bin/phpunit tests/Unit/Services/WebContentFetchServiceTest.php
+ * sail ver 実行コマンド: sail test tests/Unit/Services/WebContentFetchServiceTest.php
+ */
+class WebContentFetchServiceTest extends TestCase
+{
+    /**
+     * apiをcallして、正しい形式のレスポンスが返ってくるかをテストする
+     *
+     * @return void
+     */
+    public function test_fetchContent_withValidUrls_returnsContentArray(): void
+    {
+        // Arrange
+        $urls = [
+            'https://example.com/page1',
+            'https://example.com/page2',
+        ];
+
+        $expectedResponse = [
+            [
+                'url' => 'https://example.com/page1',
+                'title' => 'Page 1 title',
+                'content' => 'Page 1 content',
+            ],
+            [
+                'url' => 'https://example.com/page2',
+                'title' => 'Page 2 title',
+                'content' => 'Page 2 content',
+            ]
+        ];
+
+        Http::fake([
+            config('services.lambda.endpoint') => Http::response($expectedResponse),
+        ]);
+
+        $service = new WebContentFetchService();
+
+        // Act
+        $response = $service->fetchContent($urls);
+
+        // Assert
+        $this->assertEquals($expectedResponse, $response);
+    }
+
+    /**
+     * URLが空の場合は例外を投げる
+     *
+     * @return void
+     */
+    public function test_fetchContent_withEmptyUrls_throwsException(): void
+    {
+        // Arrange
+        $urls = [];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('URLs are empty.');
+
+        $service = new WebContentFetchService();
+
+        // Act
+        $service->fetchContent($urls);
+    }
+
+    /**
+     * apiをcallして、失敗した場合は例外を投げる
+     *
+     * @return void
+     */
+    public function test_fetchContent_withFailedResponse_throwsException(): void
+    {
+        // Arrange
+        $urls = [
+            'https://example.com/page1',
+            'https://example.com/page2',
+        ];
+
+        $expectedResponse = 'Failed to fetch content. Error message';
+
+        Http::fake([
+            config('services.lambda.endpoint') => Http::response($expectedResponse, 500),
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        // 場合によるので、エラーメッセージの検証は省略
+        // $this->expectExceptionMessage($expectedResponse);
+
+        $service = new WebContentFetchService();
+
+        // Act
+        $service->fetchContent($urls);
+    }
+}


### PR DESCRIPTION
* 前回のプルリクエストで定義したLambdaにPOSTしてサイト本文を取得するServiceクラスの作成
* urlを格納した配列のみを渡す形式にAPIを定義したので、RSSのパースクラスのロジックを変更対応


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - RSSパース時に特定のサイトを除外し、リンクの配列を作成する機能を追加
    - 指定したURLから本文コンテンツを取得するWebコンテンツフェッチサービスを実装
- **改善**
    - RSSパース時のリンク作成処理を最大数に制限するよう改善
- **テスト**
    - RSSパースサービスのテストケースをリンクの配列を期待するように修正
    - Webコンテンツフェッチサービスのユニットテストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->