### PR TITLE
例外発生時のSlack通知を実装

### DIFF
--- a/app/Console/Commands/ArticleSummaryNotice.php
+++ b/app/Console/Commands/ArticleSummaryNotice.php
@@ -88,7 +88,7 @@ class ArticleSummaryNotice extends Command
 
             try {
                 // 時折、文字化けにより通知失敗するので、後続処理を進めるために、try-catchにて処理
-                Notification::route('slack', config('services.slack.channel'))
+                Notification::route('slack', config('services.slack.notifications.channel'))
                     ->notify(new NewsDispatch($response));
             } catch (\Throwable $th) {
                 $this->throwError([
@@ -117,7 +117,7 @@ class ArticleSummaryNotice extends Command
     {
         logger()->error($th);
         $this->error($th->getMessage());
-        Notification::route('slack', config('services.slack.alert_channel'))
+        Notification::route('slack', config('services.slack.notifications.alert_channel'))
             ->notify(new AlertDispatch($content, $th));
     }
 }

--- a/app/Console/Commands/ArticleSummaryNotice.php
+++ b/app/Console/Commands/ArticleSummaryNotice.php
@@ -2,12 +2,14 @@
 
 namespace App\Console\Commands;
 
+use App\Notifications\AlertDispatch;
 use App\Notifications\NewsDispatch;
 use App\Services\OpenAIService;
 use App\Services\RSSParseService;
 use App\Services\WebContentFetchService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Notification;
+use Throwable;
 
 class ArticleSummaryNotice extends Command
 {
@@ -53,35 +55,69 @@ class ArticleSummaryNotice extends Command
         $this->info('記事の要約処理を開始');
         try {
             $urls = $this->rss_parse_service->fetchEntries();
-        } catch (\Throwable $th) {
-            // 通知に関してはServiceクラス内で行う
-            $this->error($th->getMessage());
+        } catch (Throwable $th) {
+            $this->throwError([
+                'class' => get_class($this->rss_parse_service),
+                'message' => 'RSSから記事のURL取得に失敗しました',
+            ], $th);
             return;
         }
 
         // 取得したURLを元に記事本文を取得する
         try {
             $contents = $this->web_content_fetch_service->fetchContent($urls);
-        } catch (\Throwable $th) {
-            // 通知に関してはServiceクラス内で行う
-            $this->error($th->getMessage());
+        } catch (Throwable $th) {
+            $this->throwError([
+                'class' => get_class($this->web_content_fetch_service),
+                'message' => 'スクレイピングによる記事本文の取得に失敗しました',
+            ], $th);
             return;
         }
 
         foreach ($contents as $content) {
             try {
-                // chatGPT apiを使用して記事を要約する
+                // openAI apiを使用して記事を要約する
                 $response = $this->openai_service->fetch($content);
+            } catch (Throwable $th) {
+                $this->throwError([
+                    'class' => get_class($this->openai_service),
+                    'message' => 'openAI apiを使用して記事の要約に失敗しました',
+                ], $th);
+                continue;
+            }
+
+            try {
                 // 時折、文字化けにより通知失敗するので、後続処理を進めるために、try-catchにて処理
                 Notification::route('slack', config('services.slack.channel'))
                     ->notify(new NewsDispatch($response));
             } catch (\Throwable $th) {
-                $this->error($th->getMessage());
+                $this->throwError([
+                    'class' => NewsDispatch::class,
+                    'message' => '記事要約のSlack通知に失敗しました',
+                ], $th);
                 // TODO: Error が発生した場合は専用のcountをインクリメント
                 // 最後に例外発生のcountを元にSlack通知を行う
-                continue;
             }
         }
         $this->info('記事の要約処理を終了');
+    }
+
+    /**
+     * エラーをログに出力する & slackに通知する
+     *
+     * @param array $content
+     * [
+     *  'class' => , // エラーが発生したクラス名
+     *  'message' => , // エラーが発生した際の直前の処理内容
+     * ]
+     * @param Throwable $th
+     * @return void
+     */
+    private function throwError(array $content, Throwable $th): void
+    {
+        logger()->error($th);
+        $this->error($th->getMessage());
+        Notification::route('slack', config('services.slack.channel'))
+            ->notify(new AlertDispatch($content, $th));
     }
 }

--- a/app/Console/Commands/ArticleSummaryNotice.php
+++ b/app/Console/Commands/ArticleSummaryNotice.php
@@ -117,7 +117,7 @@ class ArticleSummaryNotice extends Command
     {
         logger()->error($th);
         $this->error($th->getMessage());
-        Notification::route('slack', config('services.slack.channel'))
+        Notification::route('slack', config('services.slack.alert_channel'))
             ->notify(new AlertDispatch($content, $th));
     }
 }

--- a/app/Notifications/AlertDispatch.php
+++ b/app/Notifications/AlertDispatch.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Slack\BlockKit\Blocks\ContextBlock;
+use Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock;
+use Illuminate\Notifications\Slack\SlackMessage;
+use Throwable;
+
+class AlertDispatch extends Notification
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $content;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @param array $content
+     * [
+     *  'class' => '例外発生クラス名',
+     *  'message' => '処理内容'
+     * ]
+     * @param Throwable $th
+     */
+    public function __construct(array $content, Throwable $th)
+    {
+        $this->content = $this->createMessage($content, $th);
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['slack'];
+    }
+
+    /**
+     * 通知に使用するメッセージの作成
+     *
+     * @param array $content
+     * @return array
+     */
+    private function createMessage(array $content, Throwable $th): array
+    {
+        return [
+            'title' => $content['class'] . 'でエラーが発生しました',
+            'error' => $content['message'],
+            'message' => '【詳細】' . PHP_EOL . $th->getMessage() . PHP_EOL . $th->getTraceAsString(),
+        ];
+    }
+
+    /**
+     * Slackへの通知
+     *
+     * @return SlackMessage
+     */
+    public function toSlack(): SlackMessage
+    {
+        return (new SlackMessage)
+            ->headerBlock($this->content['title'])
+            ->sectionBlock(function (SectionBlock $section) {
+                $section->text($this->content['error'])
+                    ->markdown();
+            })
+            ->dividerBlock()
+            ->contextBlock(function (ContextBlock $context) {
+                $context->text($this->content['message'])
+                    ->markdown();
+            });
+    }
+}

--- a/app/Notifications/NewsDispatch.php
+++ b/app/Notifications/NewsDispatch.php
@@ -59,9 +59,6 @@ class NewsDispatch extends Notification
         // バリデーションエラーがある場合は例外をスロー
         $validator = Validator::make($content, $rules);
         if ($validator->fails()) {
-            // ログ出力は呼び出し元で行う
-            // TODO: 例外発生でのSlack通知を行う
-
             throw new \InvalidArgumentException($validator->errors()->first());
         }
     }

--- a/app/Services/OpenAIService.php
+++ b/app/Services/OpenAIService.php
@@ -32,8 +32,6 @@ class OpenAIService
             ]);
             return $this->parseResponse($result, $content);
         } catch (\Throwable $th) {
-            // TODO: slackにエラーを通知する
-            logger()->error($th);
             throw $th;
         }
     }
@@ -60,7 +58,6 @@ class OpenAIService
         $validator = validator($content, $rules);
         if ($validator->fails()) {
             throw new \InvalidArgumentException($validator->errors()->first());
-            // TODO: slackにエラーを通知する
         }
     }
 

--- a/app/Services/RSSParseService.php
+++ b/app/Services/RSSParseService.php
@@ -129,9 +129,6 @@ class RSSParseService
             }
             return $urls;
         } catch (\Throwable $th) {
-            // 例外をキャッチしてログに出力する
-            logger()->error($th);
-            // TODO: slackにエラーを通知する
             throw $th;
         }
     }

--- a/app/Services/WebContentFetchService.php
+++ b/app/Services/WebContentFetchService.php
@@ -32,9 +32,6 @@ class WebContentFetchService
             ]);
 
             if ($response->failed()) {
-                // なぜ失敗したのかをログに残す
-                logger()->error($response->body());
-                // TODO: slackにエラーを通知する
                 throw new \RuntimeException('Failed to fetch content.');
             }
 
@@ -42,8 +39,6 @@ class WebContentFetchService
             return $response->json();
 
         } catch (\Throwable $th) {
-            logger()->error($th);
-            // TODO: slackにエラーを通知する
             throw $th;
         }
     }

--- a/config/services.php
+++ b/config/services.php
@@ -45,6 +45,7 @@ return [
         'notifications' => [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),
+            'alert_channel' => env('SLACK_BOT_USER_ALERT_CHANNEL'),
         ],
     ],
 


### PR DESCRIPTION
* 例外発生を通知する専用のクラスを作成
* 作成していたServiceクラスのcatchブロックの記述を改修
* バッチ処理に例外発生時の対応メソッドを実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Slackにエラーアラートを送信するための通知機能を追加しました。
- **バグ修正**
	- エラーハンドリングと通知の処理を改善しました。
- **設定**
	- `config/services.php`に新しい設定キー`'alert_channel'`を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->