### PR TITLE
RSSから記事のタイトルを取得する形式に変更

### DIFF
--- a/.github/workflows/Integration.yml
+++ b/.github/workflows/Integration.yml
@@ -1,11 +1,6 @@
 name: Integration
 
 on:
-  push:
-    branches:
-    - main
-    - develop
-    - feature/*
   pull_request:
 
 jobs:

--- a/app/Console/Commands/ArticleSummaryNotice.php
+++ b/app/Console/Commands/ArticleSummaryNotice.php
@@ -54,7 +54,8 @@ class ArticleSummaryNotice extends Command
     {
         $this->info('記事の要約処理を開始');
         try {
-            $urls = $this->rss_parse_service->fetchEntries();
+            // 記事のURLとタイトルを取得
+            $articles = $this->rss_parse_service->fetchEntries();
         } catch (Throwable $th) {
             $this->throwError([
                 'class' => get_class($this->rss_parse_service),
@@ -65,7 +66,7 @@ class ArticleSummaryNotice extends Command
 
         // 取得したURLを元に記事本文を取得する
         try {
-            $contents = $this->web_content_fetch_service->fetchContent($urls);
+            $contents = $this->web_content_fetch_service->fetchContent($articles);
         } catch (Throwable $th) {
             $this->throwError([
                 'class' => get_class($this->web_content_fetch_service),

--- a/app/Services/WebContentFetchService.php
+++ b/app/Services/WebContentFetchService.php
@@ -12,11 +12,14 @@ class WebContentFetchService
     /**
      * 指定したURLの本文を取得する
      *
-     * @param array $urls
+     * @param array $articles
      * @return array
      */
-    public function fetchContent(array $urls): array
+    public function fetchContent(array $articles): array
     {
+        // URLのみ抜粋
+        $urls = array_column($articles, 'url');
+
         // 万が一URLが空の場合は例外を投げる
         if (empty($urls)) {
             throw new \InvalidArgumentException('URLs are empty.');
@@ -35,8 +38,18 @@ class WebContentFetchService
                 throw new \RuntimeException('Failed to fetch content.');
             }
 
-            // json形式のレスポンスを配列に変換
-            return $response->json();
+            // 取得した本文とurlで構成されるjsonを配列に変換
+            $contents = $response->json();
+
+            foreach ($articles as $key => $article) {
+                // lambdaで返される本文とurlの配列の順番は最初に渡したurlの順番と同じと思うが念のためarray_searchを使用
+                // contents の url と article の url が一致するものを取得
+                $content_key = array_search($article['url'], array_column($contents, 'url'));
+                if ($content_key !== false) {
+                    $articles[$key]['content'] = $contents[$content_key]['content'];
+                }
+            }
+            return $articles;
 
         } catch (\Throwable $th) {
             throw $th;

--- a/python-services/scraping/scraping/handler.py
+++ b/python-services/scraping/scraping/handler.py
@@ -1,7 +1,6 @@
 import json
 import traceback
 import requests
-from bs4 import BeautifulSoup
 from extractcontent3 import ExtractContent
 
 def lambda_handler(event, context):
@@ -16,10 +15,6 @@ def lambda_handler(event, context):
             res.encoding = res.apparent_encoding
             html = res.text
 
-            # BeautifulSoupでタイトルを取得
-            soup = BeautifulSoup(html, "html.parser", from_encoding=res.encoding)
-            title = soup.find("title").text if soup.find("title") else ""
-
             # extractcontent3で本文を取得
             extractor = ExtractContent()
             extractor.analyse(html)
@@ -27,7 +22,6 @@ def lambda_handler(event, context):
 
             results.append({
                 'url': url,
-                'title': title,
                 'content': text
             })
         except Exception as e:

--- a/tests/Unit/Services/RSSParseServiceTest.php
+++ b/tests/Unit/Services/RSSParseServiceTest.php
@@ -51,8 +51,14 @@ class RSSParseServiceTest extends TestCase
         $response = $rss_parse_service->fetchEntries();
 
         $expected_data = [
-            'https://example.com/item1',
-            'https://example.com/item2',
+            [
+                'title' => 'Item 1',
+                'url' => 'https://example.com/item1',
+            ],
+            [
+                'title' => 'Item 2',
+                'url' => 'https://example.com/item2',
+            ]
         ];
 
         $this->assertEquals($expected_data, $response);

--- a/tests/Unit/Services/WebContentFetchServiceTest.php
+++ b/tests/Unit/Services/WebContentFetchServiceTest.php
@@ -18,23 +18,29 @@ class WebContentFetchServiceTest extends TestCase
      *
      * @return void
      */
-    public function test_fetchContent_withValidUrls_returnsContentArray(): void
+    public function test_記事の本文取得成功(): void
     {
         // Arrange
-        $urls = [
-            'https://example.com/page1',
-            'https://example.com/page2',
+        $articles = [
+            [
+                'url' => 'https://example.com/page1',
+                'title' => 'Page 1',
+            ],
+            [
+                'url' => 'https://example.com/page2',
+                'title' => 'Page 2',
+            ]
         ];
 
         $expectedResponse = [
             [
                 'url' => 'https://example.com/page1',
-                'title' => 'Page 1 title',
+                'title' => 'Page 1',
                 'content' => 'Page 1 content',
             ],
             [
                 'url' => 'https://example.com/page2',
-                'title' => 'Page 2 title',
+                'title' => 'Page 2',
                 'content' => 'Page 2 content',
             ]
         ];
@@ -46,7 +52,7 @@ class WebContentFetchServiceTest extends TestCase
         $service = new WebContentFetchService();
 
         // Act
-        $response = $service->fetchContent($urls);
+        $response = $service->fetchContent($articles);
 
         // Assert
         $this->assertEquals($expectedResponse, $response);
@@ -57,10 +63,10 @@ class WebContentFetchServiceTest extends TestCase
      *
      * @return void
      */
-    public function test_fetchContent_withEmptyUrls_throwsException(): void
+    public function test_記事の本文取得_パラメータ不正による例外発生(): void
     {
         // Arrange
-        $urls = [];
+        $articles = [];
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('URLs are empty.');
@@ -68,7 +74,7 @@ class WebContentFetchServiceTest extends TestCase
         $service = new WebContentFetchService();
 
         // Act
-        $service->fetchContent($urls);
+        $service->fetchContent($articles);
     }
 
     /**
@@ -76,12 +82,18 @@ class WebContentFetchServiceTest extends TestCase
      *
      * @return void
      */
-    public function test_fetchContent_withFailedResponse_throwsException(): void
+    public function test_記事の本文取得_通信失敗による例外発生(): void
     {
         // Arrange
-        $urls = [
-            'https://example.com/page1',
-            'https://example.com/page2',
+        $articles = [
+            [
+                'url' => 'https://example.com/page1',
+                'title' => 'Page 1',
+            ],
+            [
+                'url' => 'https://example.com/page2',
+                'title' => 'Page 2',
+            ]
         ];
 
         $expectedResponse = 'Failed to fetch content. Error message';
@@ -97,6 +109,6 @@ class WebContentFetchServiceTest extends TestCase
         $service = new WebContentFetchService();
 
         // Act
-        $service->fetchContent($urls);
+        $service->fetchContent($articles);
     }
 }


### PR DESCRIPTION
pythonの BeautifulSoup から記事のタイトルを取得する方法から
RSSから記事のタイトルを取得する方法に変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - 記事の要約通知機能がURLのフェッチから記事のフェッチに更新されました。
    - RSSフィードから記事のタイトルとURLのペアを取得する機能が追加されました。
    - 記事のコンテンツをフェッチし、対応する記事にマッチさせる機能が更新されました。

- **リファクタ**
    - タイトル抽出のためのBeautifulSoupの使用をやめ、直接コンテンツを抽出するように変更されました。

- **テスト**
    - RSSフィードとWebコンテンツフェッチサービスのテストが更新され、より構造化されたデータ表現を期待するようになりました。
    - テストメソッド名が日本語テキストを使用するように変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->