### PR TITLE
slack通知のバグ修正 & 不要な処理のカット

### DIFF
--- a/app/Notifications/NewsDispatch.php
+++ b/app/Notifications/NewsDispatch.php
@@ -72,6 +72,14 @@ class NewsDispatch extends Notification
      */
     public function toSlack(): SlackMessage
     {
+        // memo
+        // slack 通知にて headerBlockを作成する時に、マルチバイト文字列で
+        // 150文字を超えると、substr により文字列が切り捨てられる
+        // mb_substr ではないので、不正な文字列が生成されて通知でのguzzleエラーが発生する
+        // そのため、予めこちらで文字列を切り捨てる
+        if (strlen($this->content['title']) > 150) {
+            $this->content['title'] = mb_substr($this->content['title'], 0, 60 -3, 'UTF-8') . '...';
+        }
         return (new SlackMessage)
             ->headerBlock($this->content['title'])
             ->sectionBlock(function (SectionBlock $section) {

--- a/app/Notifications/NewsDispatch.php
+++ b/app/Notifications/NewsDispatch.php
@@ -73,12 +73,14 @@ class NewsDispatch extends Notification
     public function toSlack(): SlackMessage
     {
         // memo
-        // slack 通知にて headerBlockを作成する時に、マルチバイト文字列で
-        // 150文字を超えると、substr により文字列が切り捨てられる
-        // mb_substr ではないので、不正な文字列が生成されて通知でのguzzleエラーが発生する
-        // そのため、予めこちらで文字列を切り捨てる
+        // slack 通知にて headerBlockを作成する時に
+        // 対象の文言がシングルバイト文字列で150文字を超えると、substr により文字列が切り捨てられる処理が実行される
+        // mb_substr により切り捨てではないので、不正な文字列が生成されて通知でのguzzleエラーが発生する
+        // そのため、予め文字列を切り捨てる
+        // substr を実行しているのはライブラリのコードであるため、こちらで対応する
         if (strlen($this->content['title']) > 150) {
-            $this->content['title'] = mb_substr($this->content['title'], 0, 60 -3, 'UTF-8') . '...';
+            // 切り捨て数の57は 超えていた場合に ... を付与するため あえて -3 バイトをした数値
+            $this->content['title'] = mb_substr($this->content['title'], 0, 57, 'UTF-8') . '...';
         }
         return (new SlackMessage)
             ->headerBlock($this->content['title'])

--- a/app/Services/RSSParseService.php
+++ b/app/Services/RSSParseService.php
@@ -103,13 +103,7 @@ class RSSParseService
             // レスポンスが成功した場合はRSSが正しい形式かどうかをチェックする
             $this->validateRss($response);
 
-            // Memo コメントにあるように、効率的な方法があるのかを検討する
-            // json_decode(json_encode($rss))を使用してオブジェクトを配列に変換している部分については、より効率的な方法を検討する価値があります。
-            // 例えば、SimpleXMLElementオブジェクトを直接操作して必要なデータを抽出する方法などです。
             $rss = new SimpleXMLElement($response->body());
-
-            // 一度jsonに変換してから配列に変換する
-            $rss = json_decode(json_encode($rss));
 
             // itemがchannelの中にある場合とない場合があるので、それぞれの場合で処理を分ける
             $items = $rss->channel->item ?? $rss->item;


### PR DESCRIPTION
たびたび発生していた slack 通知での不正な文字列によるバグの対応

XMLを取得した際の不要な配列変換処理のカット
#12 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **バグ修正**
    - Slack通知のヘッダーブロック作成時に、150文字を超えるマルチバイト文字列が適切に切り捨てられるように変更しました。これにより、通知時にGuzzleエラーを引き起こす無効な文字列の生成を防ぎます。
- **改善点**
    - RSSデータの処理において、非効率的なJSONエンコードおよびデコード操作を削除し、SimpleXMLElementオブジェクトを直接操作することで、処理を効率化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->